### PR TITLE
Apply custom style to parent instead of head

### DIFF
--- a/the-grid.html
+++ b/the-grid.html
@@ -264,7 +264,7 @@ Example:
 
                 // Light Dom customization using external stylesheet.
                 customStyle.appendChild(style);
-                document.head.appendChild(customStyle);
+                Polymer.dom(this).parentNode.appendChild(customStyle);
 
                 // Local DOM (Shadow or Shady) customization using inner stylesheet.
                 this.updateStyles({


### PR DESCRIPTION
This is a fix for #2 

My guess is that styles in `<head>` aren't able to trickle down into the shadow DOM of children elements.