### PR TITLE
Fix initial loading (see issue) and dispatch a dragging event (because we are cancelling the original)

### DIFF
--- a/the-grid.html
+++ b/the-grid.html
@@ -102,7 +102,7 @@ Example:
                      */
                     colCount: {
                         type: Number,
-                        value: 0,
+                        value: 10,
                         reflectToAttribute: true,
                         observer: 'computeStyles'
                     },
@@ -113,7 +113,7 @@ Example:
                      */
                     rowCount: {
                         type: Number,
-                        value: 0,
+                        value: 10,
                         reflectToAttribute: true,
                         observer: 'computeStyles'
                     },
@@ -270,9 +270,9 @@ Example:
             }
 
             ensureSpace(child) {
-                let minHeight = parseInt(child.getAttribute("row")) + parseInt(child.getAttribute("height"));
+                let minHeight = +child.getAttribute("row") + +child.getAttribute("height");
                 if(+this.rowCount === 0 && this.rowCount < minHeight) this.rowCount = minHeight;
-                let minWidth = parseInt(child.getAttribute("col")) + parseInt(child.getAttribute("width"));
+                let minWidth = +child.getAttribute("col") + +child.getAttribute("width");
                 if(+this.colCount === 0 && this.colCount < minWidth) this.colCount = minWidth;
             }
 

--- a/the-grid.html
+++ b/the-grid.html
@@ -378,31 +378,34 @@ Example:
                     player.style.left = `${newLeft}px`;
                     player.style.top = `${newTop}px`;
 
+                    if(position.col !== +this.placeholder.getAttribute("col")
+                        || position.row !== +this.placeholder.getAttribute("row")) {
+                        /**
+                         * `dragging` event when resizer/gripper is being moved.
+                         *
+                         * @event TheGrid#dragging
+                         * @type {object}
+                         * @property {HTMLElement} grid - The grid in which the event occurred.
+                         * @property {HTMLElement} tile - The tile that has been resized.
+                         * @property {Event} sourceEvent - The original tracking event.
+                         */
+                        player.dispatchEvent(new CustomEvent('dragging', {
+                            bubbles: true,
+                            composed: true,
+                            detail: {
+                                grid: this,
+                                tile: player,
+                                sourceEvent: e
+                            }
+                        }));
+                    }
+
                     // Check for overlaps if enabled.
                     if (this.overlappable || !this._isOverlapping(position.col, position.row, cols, rows, [player])) {
                         this.placeholder.setAttribute('row', position.row);
                         this.placeholder.setAttribute('col', position.col);
                         this.ensureSpace(this.placeholder);
                     }
-
-                    /**
-                     * `dragging` event when resizer/gripper is being moved.
-                     *
-                     * @event TheGrid#dragging
-                     * @type {object}
-                     * @property {HTMLElement} grid - The grid in which the event occurred.
-                     * @property {HTMLElement} tile - The tile that has been resized.
-                     * @property {Event} sourceEvent - The original tracking event.
-                     */
-                    player.dispatchEvent(new CustomEvent('dragging', {
-                        bubbles: true,
-                        composed: true,
-                        detail: {
-                            grid: this,
-                            tile: player,
-                            sourceEvent: e
-                        }
-                    }));
                 }
 
                 if (state == 'end') {
@@ -603,13 +606,13 @@ Example:
 
             }
             /**
-            * Checks if the given width or height as `value` is within grid constraints.
-            * @param {Number} value in grid unit.
-            * @param {Number} min in grid unit.
-            * @param {Number} max in grid unit.
-            * @return {Boolean} true when within constraints, otherwise false.
-            * @private
-            */
+             * Checks if the given width or height as `value` is within grid constraints.
+             * @param {Number} value in grid unit.
+             * @param {Number} min in grid unit.
+             * @param {Number} max in grid unit.
+             * @return {Boolean} true when within constraints, otherwise false.
+             * @private
+             */
             _isWithinConstraints(value, min = 1, max = Infinity) {
                 return value >= min && value <= max;
             }

--- a/the-grid.html
+++ b/the-grid.html
@@ -396,7 +396,8 @@ Example:
                                 grid: this,
                                 tile: player,
                                 col: position.col,
-                                row: position.row
+                                row: position.row,
+                                sourceEvent: e
                             }
                         }));
                     }
@@ -529,7 +530,8 @@ Example:
                                 col: size.col,
                                 row: size.row,
                                 width: size.width,
-                                height: size.height
+                                height: size.height,
+                                sourceEvent: e
                             }
                         }));
                     }

--- a/the-grid.html
+++ b/the-grid.html
@@ -431,7 +431,8 @@ Example:
                         composed: true,
                         detail: {
                             grid: this,
-                            tile: player
+                            tile: player,
+                            type: "move"
                         }
                     }));
                 }
@@ -506,6 +507,32 @@ Example:
                     isTop && newHeight >= this.cellHeight && (player.style.top = `${newTop}px`);
                     isWidth && newWidth >= this.cellWidth && (player.style.width = `${newWidth}px`);
                     isHeight && newHeight >= this.cellHeight && (player.style.height = `${newHeight}px`);
+
+                    if(size.width !== +this.placeholder.getAttribute("width")
+                        || position.height !== +this.placeholder.getAttribute("height")) {
+                        /**
+                         * `dragging` event when resizer/gripper is being moved.
+                         *
+                         * @event TheGrid#dragging
+                         * @type {object}
+                         * @property {HTMLElement} grid - The grid in which the event occurred.
+                         * @property {HTMLElement} tile - The tile that has been resized.
+                         * @property {Event} sourceEvent - The original tracking event.
+                         */
+                        player.dispatchEvent(new CustomEvent('dragging', {
+                            bubbles: true,
+                            composed: true,
+                            detail: {
+                                grid: this,
+                                tile: player,
+                                type: "resize",
+                                col: size.col,
+                                row: size.row,
+                                width: size.width,
+                                height: size.height
+                            }
+                        }));
+                    }
 
                     // Check for overlaps if enabled.
                     if (this.overlappable || !this._isOverlapping(position.col, position.row, size.width, size.height, [player])) {

--- a/the-grid.html
+++ b/the-grid.html
@@ -102,7 +102,7 @@ Example:
                      */
                     colCount: {
                         type: Number,
-                        value: 10,
+                        value: 0,
                         reflectToAttribute: true,
                         observer: 'computeStyles'
                     },
@@ -113,7 +113,7 @@ Example:
                      */
                     rowCount: {
                         type: Number,
-                        value: 10,
+                        value: 0,
                         reflectToAttribute: true,
                         observer: 'computeStyles'
                     },

--- a/the-grid.html
+++ b/the-grid.html
@@ -149,6 +149,24 @@ Example:
                         value: false,
                         reflectToAttribute: true,
                         observer: '_attachEvents'
+                    },
+
+                    /**
+                     * Internal property to control the current maxRow if rowCount is set to 0
+                     */
+                    _maxRow: {
+                        type: Number,
+                        value: 0,
+                        observer: "computeStyles"
+                    },
+
+                    /**
+                     * Internal property to control the current maxCol if colCount is set to 0
+                     */
+                    _maxCol: {
+                        type: Number,
+                        value: 0,
+                        observer: "computeStyles"
                     }
                 }
             }
@@ -221,8 +239,8 @@ Example:
                 let margin = this.cellMargin,
                     height = this.cellHeight,
                     width = this.cellWidth,
-                    cols = this.colCount,
-                    rows = this.rowCount;
+                    cols = this._shouldColSelfResize() ? this._maxCol : this.colCount,
+                    rows = this._shouldRowSelfResize() ? this._maxRow : this.rowCount;
 
                 let styleRules = '';
                 let styleVars = {
@@ -270,10 +288,22 @@ Example:
             }
 
             ensureSpace(child) {
-                let minHeight = +child.getAttribute("row") + +child.getAttribute("height");
-                if(+this.rowCount === 0 && this.rowCount < minHeight) this.rowCount = minHeight;
-                let minWidth = +child.getAttribute("col") + +child.getAttribute("width");
-                if(+this.colCount === 0 && this.colCount < minWidth) this.colCount = minWidth;
+                if(this._shouldRowSelfResize()) {
+                    let minHeight = +child.getAttribute("row") + +child.getAttribute("height");
+                    if(this._maxRow < minHeight) this._maxRow = minHeight;
+                }
+                if(this._shouldColSelfResize()) {
+                    let minWidth = +child.getAttribute("col") + +child.getAttribute("width");
+                    if (this._maxCol < minWidth) this._maxCol = minWidth;
+                }
+            }
+
+            _shouldRowSelfResize() {
+                return +this.rowCount === 0;
+            }
+
+            _shouldColSelfResize() {
+                return +this.colCount === 0;
             }
 
             /**
@@ -469,8 +499,8 @@ Example:
                 // Min = 0.
                 // Max = grid size - player size.
                 return {
-                    col: Math.max(Math.min(position.col, +this.colCount === 0 ? Infinity : this.colCount - cols), 0),
-                    row: Math.max(Math.min(position.row, +this.rowCount === 0 ? Infinity : this.rowCount - rows), 0)
+                    col: Math.max(Math.min(position.col, this._shouldColSelfResize() ? Infinity : this.colCount - cols), 0),
+                    row: Math.max(Math.min(position.row, this._shouldRowSelfResize() ? Infinity : this.rowCount - rows), 0)
                 }
 
             }
@@ -493,8 +523,8 @@ Example:
                 // Min = 1.
                 // Max = grid size (or provided max)
                 return {
-                    width: Math.max(Math.min(size.width, +this.colCount === 0 ? Infinity : maxWidth), 1),
-                    height: Math.max(Math.min(size.height, +this.rowCount === 0 ? Infinity : maxHeight), 1)
+                    width: Math.max(Math.min(size.width, this._shouldColSelfResize() ? Infinity : maxWidth), 1),
+                    height: Math.max(Math.min(size.height, this._shouldRowSelfResize() ? Infinity : maxHeight), 1)
                 }
             }
 

--- a/the-grid.html
+++ b/the-grid.html
@@ -149,17 +149,6 @@ Example:
                         value: false,
                         reflectToAttribute: true,
                         observer: '_attachEvents'
-                    },
-
-                    /**
-                     * Enable infinite automatic extension of the grid on resize and move.
-                     * @type {boolean}
-                     */
-                    selfResize: {
-                        type: Boolean,
-                        value: true,
-                        reflectToAttribute: true,
-                        observer: '_attachEvents'
                     }
                 }
             }
@@ -177,6 +166,7 @@ Example:
 
                 this.addEventListener('dom-change', this._attachEvents);
                 this._attachEvents();
+                this.computeStyles();
             }
 
             /**
@@ -190,8 +180,7 @@ Example:
                 let addOrRemoveMoveListener = this.draggable ? 'addListener' : 'removeListener';
 
                 Array.prototype.forEach.call(this.children, child => {
-                    this.ensureSpaceIfSelfResizing(child);
-                    this.computeStyles();
+                    this.ensureSpace(child);
                     let isPlaceholder = child.hasAttribute('placeholder');
                     if (isPlaceholder) {
                         this.placeholder = child;
@@ -280,12 +269,11 @@ Example:
 
             }
 
-            ensureSpaceIfSelfResizing(child) {
-                if(!this.selfResize) return;
+            ensureSpace(child) {
                 let minHeight = parseInt(child.getAttribute("row")) + parseInt(child.getAttribute("height"));
-                if(this.rowCount < minHeight) this.rowCount = minHeight;
+                if(+this.rowCount === 0 && this.rowCount < minHeight) this.rowCount = minHeight;
                 let minWidth = parseInt(child.getAttribute("col")) + parseInt(child.getAttribute("width"));
-                if(this.colCount < minWidth) this.colCount = minWidth;
+                if(+this.colCount === 0 && this.colCount < minWidth) this.colCount = minWidth;
             }
 
             /**
@@ -293,7 +281,6 @@ Example:
              * @private
              */
             _handleMove(e) {
-                e.stopPropagation();
 
                 let player = e.target,
                     state = e.detail.state;
@@ -332,13 +319,13 @@ Example:
                     player.style.top = `${newTop}px`;
                     this.placeholder.setAttribute('row', position.row);
                     this.placeholder.setAttribute('col', position.col);
-                    this.ensureSpaceIfSelfResizing(this.placeholder);
+                    this.ensureSpace(this.placeholder);
                 }
 
                 if (state == 'end') {
                     player.setAttribute('row', this.placeholder.getAttribute('row'));
                     player.setAttribute('col', this.placeholder.getAttribute('col'));
-                    this.ensureSpaceIfSelfResizing(player);
+                    this.ensureSpace(player);
                     player.style.left = '';
                     player.style.top = '';
                     player.style.transition = '';
@@ -348,6 +335,7 @@ Example:
 
                 this._safePreventDefault(e.detail.sourceEvent);
                 e.preventDefault();
+                e.stopPropagation();
 
             }
 
@@ -413,7 +401,7 @@ Example:
                     isLeft && this.placeholder.setAttribute('col', position.col);
                     isHeight && this.placeholder.setAttribute('height', size.height);
                     isWidth && this.placeholder.setAttribute('width', size.width);
-                    this.ensureSpaceIfSelfResizing(this.placeholder);
+                    this.ensureSpace(this.placeholder);
                 }
 
                 if (state == 'end') {
@@ -421,7 +409,7 @@ Example:
                     player.setAttribute('col', this.placeholder.getAttribute('col'));
                     player.setAttribute('width', this.placeholder.getAttribute('width'));
                     player.setAttribute('height', this.placeholder.getAttribute('height'));
-                    this.ensureSpaceIfSelfResizing(this.placeholder);
+                    this.ensureSpace(this.placeholder);
                     player.style.transition = 'var(--grid-resize-animation-transition)';
                     player.style.left = '';
                     player.style.top = '';
@@ -481,8 +469,8 @@ Example:
                 // Min = 0.
                 // Max = grid size - player size.
                 return {
-                    col: Math.max(Math.min(position.col, this.selfResize ? Infinity : this.colCount - cols), 0),
-                    row: Math.max(Math.min(position.row, this.selfResize ? Infinity : this.rowCount - rows), 0)
+                    col: Math.max(Math.min(position.col, +this.colCount === 0 ? Infinity : this.colCount - cols), 0),
+                    row: Math.max(Math.min(position.row, +this.rowCount === 0 ? Infinity : this.rowCount - rows), 0)
                 }
 
             }
@@ -505,8 +493,8 @@ Example:
                 // Min = 1.
                 // Max = grid size (or provided max)
                 return {
-                    width: Math.max(Math.min(size.width, this.selfResize ? Infinity : maxWidth), 1),
-                    height: Math.max(Math.min(size.height, this.selfResize ? Infinity : maxHeight), 1)
+                    width: Math.max(Math.min(size.width, +this.colCount === 0 ? Infinity : maxWidth), 1),
+                    height: Math.max(Math.min(size.height, +this.rowCount === 0 ? Infinity : maxHeight), 1)
                 }
             }
 

--- a/the-grid.html
+++ b/the-grid.html
@@ -395,7 +395,8 @@ Example:
                             detail: {
                                 grid: this,
                                 tile: player,
-                                sourceEvent: e
+                                col: position.col,
+                                row: position.row
                             }
                         }));
                     }

--- a/the-grid.html
+++ b/the-grid.html
@@ -149,6 +149,17 @@ Example:
                         value: false,
                         reflectToAttribute: true,
                         observer: '_attachEvents'
+                    },
+
+                    /**
+                     * Enable infinite automatic extension of the grid on resize and move.
+                     * @type {boolean}
+                     */
+                    selfResize: {
+                        type: Boolean,
+                        value: true,
+                        reflectToAttribute: true,
+                        observer: '_attachEvents'
                     }
                 }
             }
@@ -179,6 +190,8 @@ Example:
                 let addOrRemoveMoveListener = this.draggable ? 'addListener' : 'removeListener';
 
                 Array.prototype.forEach.call(this.children, child => {
+                    this.ensureSpaceIfSelfResizing(child);
+                    this.computeStyles();
                     let isPlaceholder = child.hasAttribute('placeholder');
                     if (isPlaceholder) {
                         this.placeholder = child;
@@ -267,11 +280,21 @@ Example:
 
             }
 
+            ensureSpaceIfSelfResizing(child) {
+                if(!this.selfResize) return;
+                let minHeight = parseInt(child.getAttribute("row")) + parseInt(child.getAttribute("height"));
+                if(this.rowCount < minHeight) this.rowCount = minHeight;
+                let minWidth = parseInt(child.getAttribute("col")) + parseInt(child.getAttribute("width"));
+                if(this.colCount < minWidth) this.colCount = minWidth;
+            }
+
             /**
              * Process events related to a player being moved.
              * @private
              */
             _handleMove(e) {
+                e.stopPropagation();
+
                 let player = e.target,
                     state = e.detail.state;
 
@@ -309,11 +332,13 @@ Example:
                     player.style.top = `${newTop}px`;
                     this.placeholder.setAttribute('row', position.row);
                     this.placeholder.setAttribute('col', position.col);
+                    this.ensureSpaceIfSelfResizing(this.placeholder);
                 }
 
                 if (state == 'end') {
                     player.setAttribute('row', this.placeholder.getAttribute('row'));
-                    player.setAttribute('col', this.placeholder.getAttribute('col'))
+                    player.setAttribute('col', this.placeholder.getAttribute('col'));
+                    this.ensureSpaceIfSelfResizing(player);
                     player.style.left = '';
                     player.style.top = '';
                     player.style.transition = '';
@@ -368,8 +393,8 @@ Example:
                     let newTop = top + e.detail.ddy;
                     let newWidth = width + (isLeft ? -e.detail.ddx : e.detail.ddx);
                     let newHeight = height + (isTop ? -e.detail.ddy : e.detail.ddy);
-                    let row = +player.getAttribute('row')
-                    let col = +player.getAttribute('col')
+                    let row = +player.getAttribute('row');
+                    let col = +player.getAttribute('col');
                     let cols = +player.getAttribute('width');
                     let rows = +player.getAttribute('height');
                     let position = this.getClosestPosition(newLeft, newTop, 1, 1, isTop || isLeft);
@@ -388,6 +413,7 @@ Example:
                     isLeft && this.placeholder.setAttribute('col', position.col);
                     isHeight && this.placeholder.setAttribute('height', size.height);
                     isWidth && this.placeholder.setAttribute('width', size.width);
+                    this.ensureSpaceIfSelfResizing(this.placeholder);
                 }
 
                 if (state == 'end') {
@@ -395,6 +421,7 @@ Example:
                     player.setAttribute('col', this.placeholder.getAttribute('col'));
                     player.setAttribute('width', this.placeholder.getAttribute('width'));
                     player.setAttribute('height', this.placeholder.getAttribute('height'));
+                    this.ensureSpaceIfSelfResizing(this.placeholder);
                     player.style.transition = 'var(--grid-resize-animation-transition)';
                     player.style.left = '';
                     player.style.top = '';
@@ -454,8 +481,8 @@ Example:
                 // Min = 0.
                 // Max = grid size - player size.
                 return {
-                    col: Math.max(Math.min(position.col, this.colCount - cols), 0),
-                    row: Math.max(Math.min(position.row, this.rowCount - rows), 0)
+                    col: Math.max(Math.min(position.col, this.selfResize ? Infinity : this.colCount - cols), 0),
+                    row: Math.max(Math.min(position.row, this.selfResize ? Infinity : this.rowCount - rows), 0)
                 }
 
             }
@@ -478,8 +505,8 @@ Example:
                 // Min = 1.
                 // Max = grid size (or provided max)
                 return {
-                    width: Math.max(Math.min(size.width, maxWidth), 1),
-                    height: Math.max(Math.min(size.height, maxHeight), 1)
+                    width: Math.max(Math.min(size.width, this.selfResize ? Infinity : maxWidth), 1),
+                    height: Math.max(Math.min(size.height, this.selfResize ? Infinity : maxHeight), 1)
                 }
             }
 

--- a/the-grid.html
+++ b/the-grid.html
@@ -216,7 +216,6 @@ Example:
                 super.connectedCallback();
                 this.addEventListener('dom-change', this._attachEvents);
                 this._attachEvents();
-                this.computeStyles();
             }
 
             /**
@@ -230,6 +229,7 @@ Example:
                 let addOrRemoveMoveListener = this.draggable ? 'addListener' : 'removeListener';
 
                 Array.prototype.forEach.call(this.children, child => {
+                    this.ensureSpace(child);
                     let isPlaceholder = child.hasAttribute('placeholder');
                     if (isPlaceholder) {
                         this.placeholder = child;
@@ -248,7 +248,7 @@ Example:
                         child.addEventListener('touchmove', this._safePreventDefault);
                     }
                 });
-
+                this.computeStyles();
             }
 
             /**
@@ -384,6 +384,25 @@ Example:
                         this.placeholder.setAttribute('col', position.col);
                         this.ensureSpace(this.placeholder);
                     }
+
+                    /**
+                     * `dragging` event when resizer/gripper is being moved.
+                     *
+                     * @event TheGrid#dragging
+                     * @type {object}
+                     * @property {HTMLElement} grid - The grid in which the event occurred.
+                     * @property {HTMLElement} tile - The tile that has been resized.
+                     * @property {Event} sourceEvent - The original tracking event.
+                     */
+                    player.dispatchEvent(new CustomEvent('dragging', {
+                        bubbles: true,
+                        composed: true,
+                        detail: {
+                            grid: this,
+                            tile: player,
+                            sourceEvent: e
+                        }
+                    }));
                 }
 
                 if (state == 'end') {


### PR DESCRIPTION
Well, since this might not be the only possible solution, I'm going to share the problem I'm trying to solve: I want to 

1. know when any element on the page is dragged and therefore catch some form of track event from Polymer
2. not removing the `stopPropagation` again, because then nested `the-grid`s don't work anymore

So I made up this custom event which I'm currently using in my local branch of this component. If you have another better idea to solve this, let me know!