### PR TITLE
Move tile - instead of not doing the move find the right child

### DIFF
--- a/the-grid.html
+++ b/the-grid.html
@@ -346,7 +346,16 @@ Example:
                     state = e.detail.state;
 
                 // Only handle direct children of the grid.
-                if (Polymer.dom(player).parentNode !== this) return;
+                //If the event does not come from a direct child find the right child and use it as target
+                if (Polymer.dom(player).parentNode !== this) {
+                    e.path.forEach(item => {
+                        if(Polymer.dom(item).parentNode === that) {
+                            player = item;
+                        }
+                    });
+                    //Well it defintly wasn´t a child so stop this!
+                    if (Polymer.dom(player).parentNode !== this) return;
+                }
 
                 // Create a placeholder if not present.
                 if (!this.placeholder) {


### PR DESCRIPTION
This little fix will do the move of a tile even when the event target was not a direct child a the-grid. Instead it will go up the event path and find the correct child and use this as event target. This is needed if a depply structured Custom Element is used as tile.