### PR TITLE
Add tile mixin

### DIFF
--- a/the-grid.html
+++ b/the-grid.html
@@ -49,6 +49,11 @@ Example:
                 display: none;
                 transition: none;
             }
+            
+            #container > ::slotted(tile) {
+              @apply --the-grid-tile;
+            }
+
         </style>
 
         <div id="container">


### PR DESCRIPTION
Styling tiles from consuming component works fine with native browsers, but polyfilled browsers do not respect those styles. This PR adds a mixin for slotted `tile` elements which works across browsers.